### PR TITLE
Fix \ No newline at end of file

### DIFF
--- a/link.js
+++ b/link.js
@@ -45,6 +45,6 @@ prompt.start();
 prompt.get(schema, function (err, result) {
    const obj = {'title': result.title.trim(), 'url': result.url.trim(), 'cat': result.category.trim()};
    fullList.push(obj);
-   fs.writeFileSync('./list.json', JSON.stringify(fullList, null, 4));
+   fs.writeFileSync('./list.json', JSON.stringify(fullList, null, 4) + '\n');
    console.log('New link added!');
 });


### PR DESCRIPTION
Issue: **\ No newline at end of file**
Command
```
>node link
prompt: Link title:  try
prompt: Link URL:  http://try.com
prompt: Category (book,podcast,video,article,newsletter):  book
New link added!
```

Result
```
>git diff
diff --git a/list.json b/list.json
index 25529bd..c230aae 100644
--- a/list.json
+++ b/list.json
@@ -438,8 +438,8 @@
         "title": "Cloning Yourself Isn’t an Option – Camille Fournier at The Lead Developer 2015",
         "url": "https://vimeo.com/139907569",
         "cat": "video"
-     },
-     {
+    },
+    {
         "title": "The Manager's Path: A Guide for Tech Leaders Navigating Growth and Change",
         "url": "https://www.amazon.com/Managers-Path-Leaders-Navigating-Growth/dp/1491973897",
         "cat": "book"
@@ -478,5 +478,10 @@
         "title": "Joel on Software: Tech Lead reading list",
         "url": "https://www.joelonsoftware.com/category/reading-lists/tech-lead/",
         "cat": "article"
+    },
+    {
+        "title": "try",
+        "url": "http://try.com",
+        "cat": "book"
     }
-]
+]
\ No newline at end of file
```