### PR TITLE
feat: use docsify to statically host as website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# Engineering Manager Resources 
- A list of engineering manager resource links. 
- 
- Follow [Ryan Burgess on Twitter](http://twitter.com/burgessdryan)
+
 
 ## Mentoring
  * [Plato](https://www.platohq.com/)

--- a/_coverpage.md
+++ b/_coverpage.md
@@ -1,0 +1,7 @@
+<!-- _coverpage.md -->
+
+# Engineering Manager Resources.
+
+> A list of engineering manager resource links
+
+[Follow Ryan on Twitter](http://twitter.com/burgessdryan)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      coverpage: true,
+      name: 'Engineer Manager',
+      repo: 'https://github.com/ryanburgess/engineer-manager',
+      search: {
+        paths: 'auto',
+        noData: {
+          '/': 'No results!'
+        }
+      },
+    }
+  </script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/emoji.min.js"></script>
+</body>
+</html>

--- a/lib/update.js
+++ b/lib/update.js
@@ -10,7 +10,7 @@ module.exports = function update() {
   const communities = [];
   const courses = [];
 
-  let content = '# Engineering Manager Resources \n A list of engineering manager resource links. \n \n Follow [Ryan Burgess on Twitter](http://twitter.com/burgessdryan)';
+  let content = '';
 
    // create lists of resources
    for (const resource of obj) {


### PR DESCRIPTION
## Why

I found this repo extremely helpful, I thought it was worthy of being a website that is a little bit friendly from a viewer's perspective.

To see how it looks locally run:
```bash
npm i docsify-cli -g
docsify serve
```

After merging the PR you can use GitHub pages to host it: 
<img width="759" alt="image" src="https://user-images.githubusercontent.com/11285350/162060101-57001ef5-982d-44ce-9c81-44026e8932a6.png">

There are also other [plugins](https://docsify.js.org/#/awesome?id=plugins) available to add/enhance functionality, for example GA so you could see who is going to the site 😄 

#### Screenshots

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/11285350/162060647-66a15e73-cb43-41d0-8c53-cb09095057ff.png">
<img width="1376" alt="image" src="https://user-images.githubusercontent.com/11285350/162060675-cddda450-7381-467c-9205-cf26734a9837.png">
